### PR TITLE
Add water_meter to YoulessAPI and YoulessDevice

### DIFF
--- a/youless_api/__init__.py
+++ b/youless_api/__init__.py
@@ -64,6 +64,14 @@ class YoulessAPI:
         return None
 
     @property
+    def water_meter(self) -> Optional[YoulessSensor]:
+        """"Get the water data available."""
+        if self._device is not None:
+            return self._device.water_meter
+
+        return None
+
+    @property
     def gas_meter(self) -> Optional[YoulessSensor]:
         """"Get the gas data available."""
         if self._device is not None:

--- a/youless_api/device/__init__.py
+++ b/youless_api/device/__init__.py
@@ -35,6 +35,11 @@ class YouLessDevice:
         return None
 
     @property
+    def water_meter(self) -> Optional[YoulessSensor]:
+        """"Get the water data available."""
+        return None
+
+    @property
     def gas_meter(self) -> Optional[YoulessSensor]:
         """"Get the gas data available."""
         return None


### PR DESCRIPTION
When trying to update the home-assistant component with the new water meter capabilities in version 1.1.0, the following error showed up:
AttributeError: 'YoulessAPI' object has no attribute 'water_meter'.

It seems water_meter was was added to LS120 but missing from both YoulessAPI and YoulessDevice.
